### PR TITLE
詳細ページの404ページを作成、fontがダサいので明朝はやめる

### DIFF
--- a/src/app/member/[slug]/page.tsx
+++ b/src/app/member/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { use, cache } from 'react'
 import CssBaseline from '@mui/material/CssBaseline'
 import Container from '@mui/material/Container'
 import Box from '@mui/material/Box'
-import { useRouter } from 'next/navigation'
+import { useRouter, notFound } from 'next/navigation'
 
 // components
 import { NormalButton, Hero } from '~/components'
@@ -39,8 +39,7 @@ export default function Page({ params }: { params: { slug: string } }) {
   const data = use(getData(params.slug))
   const router = useRouter()
   if (!data) {
-    // MEMO:404に飛ばしたい
-    return <div>not found</div>
+    notFound()
   }
 
   return (
@@ -49,7 +48,7 @@ export default function Page({ params }: { params: { slug: string } }) {
       <Container maxWidth="lg">
         <Box
           sx={{
-            my: 4,
+            my: 5,
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'center',

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource @emotion/react */
+'use client'
+import CssBaseline from '@mui/material/CssBaseline'
+import Container from '@mui/material/Container'
+import { css } from '@emotion/react'
+import { useRouter } from 'next/navigation'
+import Typography from '@mui/material/Typography'
+
+// components
+import { NormalButton, Title, Section } from '~/components'
+
+export default function NotFound() {
+  const router = useRouter()
+  return (
+    <>
+      <CssBaseline />
+      <Container maxWidth="lg">
+        <Section>
+          <Title text={'Not Found'} />
+          <Typography
+            component="p"
+            css={css`
+              padding: 40px 0 100px;
+              font-size: 22px;
+            `}
+          >
+            お探しのページが見つかりませんでした
+            <br />
+            URLが間違っているか、ページが存在しません。
+          </Typography>
+          <NormalButton variant="contained" clickHandler={() => router.push('/')}>
+            トップページへ戻る
+          </NormalButton>
+        </Section>
+      </Container>
+    </>
+  )
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,7 +9,8 @@ import { red } from '@mui/material/colors'
 // Create a theme instance.
 const theme = createTheme({
   typography: {
-    fontFamily: '"Hiragino Mincho ProN", "Yu Mincho", "MS PMincho", serif',
+    fontFamily:
+      '"Helvetica Neue", "Helvetica", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif',
     fontSize: 14,
     fontWeightLight: 300,
     fontWeightRegular: 400,


### PR DESCRIPTION
こちらのページのみ作成、
http://localhost:3000/member/hoge

グローバルはまだ、非対応らしいです。
https://beta.nextjs.org/docs/upgrade-guide#migrating-from-pages-to-app